### PR TITLE
View/templates/clean up

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -15,35 +14,25 @@ var (
 
 func home(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
-
-	if err := homeView.Template.ExecuteTemplate(w, homeView.Layout, nil); err != nil {
-		panic(err)
-	}
+	must(homeView.Render(w, nil))
 }
 
 func contact(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
-	if err := contactView.Template.ExecuteTemplate(w, contactView.Layout, nil); err != nil {
-		panic(err)
-	}
-}
-func faq(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html")
-	_, _ = fmt.Fprint(w, "<ul><li><strong>Q: Is this course hard?</strong> A: Not so, in fact, it's pretty easy for now.</li><li><strong>Q: Is this course mqde for me?</strong> A: You've got a 30 days cashback guarantee.</li><li><strong>Q: What about beginners?</strong> A: This course is tailored to fit for both beginners and more advanced developers.</li><li><strong>Q: Why is it not like, 10 bucks or so like Udemy?</strong> A: Because I really worked to produce this one.</li></ul>")
+	must(contactView.Render(w, nil))
 }
 
-func four_oh_four(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusNotFound)
-	fmt.Fprint(w, "<h1>Ooops, something's missing here... We should fire someone 🤷‍♂️</h1>")
-}
 func main() {
 	homeView = views.NewView("bootstrap", "views/home.gohtml")
 	contactView = views.NewView("bootstrap", "views/contact.gohtml")
 	r := mux.NewRouter()
 	r.HandleFunc("/", home)
 	r.HandleFunc("/contact", contact)
-	r.HandleFunc("/faq", faq)
-	r.NotFoundHandler = http.HandlerFunc(four_oh_four)
 	http.ListenAndServe(":3000", r)
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/views/contact.gohtml
+++ b/views/contact.gohtml
@@ -4,6 +4,4 @@
         To get in touch, please send an email to
         <a href="mailto:william.martin@hey.com">william.martin@hey.com</a>
     </p>
-
-    {{template "footer"}}
 {{end}}

--- a/views/home.gohtml
+++ b/views/home.gohtml
@@ -1,5 +1,3 @@
 {{define "yield"}}
     <h1>Home page right now</h1>
-
-    {{template "footer"}}
 {{end}}

--- a/views/layouts/bootstrap.gohtml
+++ b/views/layouts/bootstrap.gohtml
@@ -23,6 +23,12 @@
     <script defer src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
     <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
     </body>
+
+    <footer class="footer mt-auto py-3">
+        <div class="container">
+            <span class="text-muted">Lens Locked © 2020</span>
+        </div>
+    </footer>
 </html>
 
 

--- a/views/layouts/footer.gohtml
+++ b/views/layouts/footer.gohtml
@@ -1,5 +1,0 @@
-{{define "footer"}}
-<footer>
-    <p>Copyright Lenslocked.com © 2020</p>
-</footer>
-{{end}}

--- a/views/view.go
+++ b/views/view.go
@@ -1,18 +1,22 @@
 package views
 
-import "html/template"
+import (
+	"html/template"
+	"path/filepath"
+)
 
 type View struct {
 	Template *template.Template
 	Layout   string
 }
 
+var (
+	LayoutDir   string = "views/layouts/"
+	TemplateExt string = ".gohtml"
+)
+
 func NewView(layout string, files ...string) *View {
-	files = append(files,
-		"views/layouts/navbar.gohtml",
-		"views/layouts/bootstrap.gohtml",
-		"views/layouts/footer.gohtml",
-	)
+	files = append(files, layoutFiles()...)
 
 	t, err := template.ParseFiles(files...)
 	if err != nil {
@@ -23,4 +27,14 @@ func NewView(layout string, files ...string) *View {
 		Template: t,
 		Layout:   layout,
 	}
+}
+
+//layoutFiles return a slice of strings
+//representing the layout files used in the application.
+func layoutFiles() []string {
+	files, err := filepath.Glob(LayoutDir + "*" + TemplateExt)
+	if err != nil {
+		panic(err)
+	}
+	return files
 }

--- a/views/view.go
+++ b/views/view.go
@@ -2,6 +2,7 @@ package views
 
 import (
 	"html/template"
+	"net/http"
 	"path/filepath"
 )
 
@@ -27,6 +28,11 @@ func NewView(layout string, files ...string) *View {
 		Template: t,
 		Layout:   layout,
 	}
+}
+
+// Render is used to render the view with the predefined layout.
+func (v *View) Render(w http.ResponseWriter, data interface{}) error {
+	return v.Template.ExecuteTemplate(w, v.Layout, data)
 }
 
 //layoutFiles return a slice of strings


### PR DESCRIPTION
Clean up the view.go file.
Add more convenient way to render pages, less error prone. With globing and a Render method attached to the view type.
Move the footer into the bootstrap template file.
